### PR TITLE
Remove key derivation function from ed25519-recovery

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -47,23 +47,6 @@ func NewKeyFromSeed(seed []byte) PrivateKey {
 	return ed25519.NewKeyFromSeed(seed)
 }
 
-// NewDerivedKeyFromSeed calculates a private key from a 32 bytes random seed,
-// an integer index and salt.
-func NewDerivedKeyFromSeed(seed []byte, index uint64, salt []byte) PrivateKey {
-	if l := len(seed); l != SeedSize {
-		panic("ed25519: bad seed length: " + strconv.Itoa(l))
-	}
-
-	digest := sha512.New()
-	digest.Write(seed)
-	digest.Write(salt)
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, index)
-	digest.Write(buf)
-
-	return NewKeyFromSeed(digest.Sum(nil)[:SeedSize])
-}
-
 // ExtractPublicKey extracts the signer's public key given a message and its
 // signature. It will panic if len(sig) is not [SignatureSize].
 //


### PR DESCRIPTION
Since the key derivation that is currently implemented isn't properly specified and will soon be replaced we should get rid of it.